### PR TITLE
chore: updated my website URL

### DIFF
--- a/data/members.json
+++ b/data/members.json
@@ -65,8 +65,8 @@
   { "name": "Robb Knight", "feed": "https://rknight.me/feed.xml", "url": "https://rknight.me/" },
   {
     "name": "Nick Taylor",
-    "feed": "https://www.iamdeveloper.com/feed.xml",
-    "url": "https://www.iamdeveloper.com/"
+    "feed": "https://www.nickyt.co/feed",
+    "url": "https://www.nickyt.co/"
   },
   {
     "name": "Matthew Peck-Deloughry",


### PR DESCRIPTION
Just a small update. I've made the main URL of my site www.nickyt.co.

<img src="https://media0.giphy.com/media/d1E2IByItLUuONMc/giphy.gif"/>